### PR TITLE
feat: AppMention support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ COPY startup/ally.toml /cf-cli
 ADD bin/ally-linux-amd64 /usr/local/bin/ally
 RUN rm -f /root/.cfconfig
 
+# Install Github CLI
+RUN apk add github-cli
+
 ENTRYPOINT ["/usr/local/bin/ally"]

--- a/codefresh.go
+++ b/codefresh.go
@@ -75,15 +75,7 @@ func fileExists(f string) bool {
 	return !info.IsDir()
 }
 
-func runCodefreshPipeline(api *slack.Client, config *c, callback slack.InteractionCallback) error {
-	var repo string
-	if callback.BlockActionState != nil {
-		actions := callback.BlockActionState.Values
-		for _, action := range actions {
-			repo = action[SlackTriggerTechAllyProject].SelectedOption.Value
-		}
-	}
-
+func runCodefreshPipeline(api *slack.Client, config *c, callback slack.InteractionCallback, repo string) error {
 	if repo == "" {
 		return errors.New("callback event had no repository")
 	}
@@ -106,11 +98,9 @@ func runCodefreshPipeline(api *slack.Client, config *c, callback slack.Interacti
 	defer func() {
 		if success {
 			updateSlackMessage(api, callback.Channel.ID, timestamp,
-				slack.MsgOptionText(":white_check_mark: Triggered! (project: *"+repo+"*)", false),
-			)
-			postSlackMessage(api, callback.Channel.ID,
 				slack.MsgOptionText(
-					"_:eyes: Look at <#"+config.NotifySlackChannel+"> for the release PR._", false),
+					":white_check_mark: Triggered! (project: *"+repo+"*)\n\n"+
+						"_:eyes: Look at <#"+config.NotifySlackChannel+"> for the release PR._", false),
 			)
 			return
 		}

--- a/deployment/task-definition.json
+++ b/deployment/task-definition.json
@@ -36,11 +36,15 @@
                   "name": "SLACK_BOT_TOKEN",
                   "valueFrom": "arn:aws:secretsmanager:us-west-2:463783698038:secret:ally-release-slack-app-tWDc71:SLACK_BOT_TOKEN::"
             },
-	    {
+            {
                   "name": "SLACK_APP_TOKEN",
                   "valueFrom": "arn:aws:secretsmanager:us-west-2:463783698038:secret:ally-release-slack-app-tWDc71:SLACK_APP_TOKEN::"
             },
-	    {
+            {
+                  "name": "GH_TOKEN",
+                  "valueFrom": "arn:aws:secretsmanager:us-west-2:463783698038:secret:ally-release-slack-app-tWDc71:GH_TOKEN::"
+            },
+            {
                   "name": "CODEFRESH_API_KEY",
                   "valueFrom": "arn:aws:secretsmanager:us-west-2:463783698038:secret:ally-release-slack-app-tWDc71:CODEFRESH_API_KEY::"
             }

--- a/gh_cli.go
+++ b/gh_cli.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+func githubCLIExists() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}
+
+func (config *c) verifyGithubCLIConfig() error {
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		return errors.New("GH_TOKEN must be set")
+	}
+	return nil
+}

--- a/gh_cli.go
+++ b/gh_cli.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/slack-go/slack"
 )
 
 func githubCLIExists() bool {
@@ -18,4 +23,202 @@ func (config *c) verifyGithubCLIConfig() error {
 		return errors.New("GH_TOKEN must be set")
 	}
 	return nil
+}
+
+func runGithubAction(api *slack.Client, channel, args string) error {
+	timestamp := postSlackMessage(api, channel,
+		slack.MsgOptionText(
+			fmt.Sprintf(":waiting: Running Github Action with args: '%s' :rocket:", args),
+			false,
+		))
+
+	var success bool
+	defer func() {
+		if success {
+			updateSlackMessage(api, channel, timestamp,
+				slack.MsgOptionText(":white_check_mark: That was a success!", false),
+			)
+			return
+		}
+		updateSlackMessage(api, channel, timestamp,
+			slack.MsgOptionText(
+				":x: Something went wrong while running the Github Action!", false),
+		)
+	}()
+
+	cmd := GenerateGithubCommandWithArgs(args)
+	logger.Infow("running github workflow", "command", cmd.String())
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return errors.Wrap(err, "unable to create StdoutPipe")
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return errors.Wrap(err, "unable to create StderrPipe")
+	}
+
+	merged := io.MultiReader(stderr, stdout)
+	go readCommandBuffer(bufio.NewScanner(merged))
+
+	if err := cmd.Start(); err != nil {
+		return errors.Wrap(err, "unable to start command, buffer error")
+	}
+
+	err = cmd.Wait()
+	if err == nil {
+		success = true
+	}
+	return err
+}
+
+func GenerateGithubCommandWithArgs(args string) *exec.Cmd {
+	cmd := []string{"workflow", "run"}
+	return exec.Command("gh", append(cmd, strings.Split(args, " ")...)...)
+}
+
+func runGithubActionWithCallback(api *slack.Client, config *c,
+	callback slack.InteractionCallback, mfaToken, tag string) error {
+	if mfaToken == "" {
+		return errors.New("unable to process callback event, missing MFA token")
+	}
+	if tag == "" {
+		return errors.New("unable to process callback event, missing Github tag")
+	}
+
+	notifySlackChannel(api,
+		config.NotifySlackChannel,
+		fmt.Sprintf(
+			"User %s approved signing of the *Lacework CLI %s* :chewbacca:",
+			callback.User.Name, tag,
+		),
+	)
+
+	// Update the same message which is built by renderPayloadToSignCLI()
+	// and remove the last two blocks that asks for the MFA token and has
+	// the button to approve.
+	//
+	// Instead, tell everyone who approved it!
+	approverText := slack.NewTextBlockObject(
+		slack.MarkdownType,
+		fmt.Sprintf("\n:white_check_mark: *Approved by %s*", callback.User.Name),
+		false, false)
+	approverSection := slack.NewSectionBlock(approverText, nil, nil)
+
+	updatedMessage := []slack.Block{
+		callback.Message.Blocks.BlockSet[0],
+		callback.Message.Blocks.BlockSet[1],
+		approverSection,
+	}
+
+	postSlackMessage(api, callback.Channel.ID,
+		slack.MsgOptionBlocks(updatedMessage...),
+		slack.MsgOptionReplaceOriginal(callback.ResponseURL),
+	)
+
+	timestamp := postSlackMessage(api, callback.Channel.ID,
+		slack.MsgOptionText(
+			fmt.Sprintf(
+				":waiting: Running Github Action to sign the *Lacework CLI %s* :rocket:", tag,
+			),
+			false,
+		),
+	)
+
+	var success bool
+	defer func() {
+		if success {
+			updateSlackMessage(api, callback.Channel.ID, timestamp,
+				slack.MsgOptionText("That was a success! :chewbacca:", false),
+			)
+			return
+		}
+		updateSlackMessage(api, callback.Channel.ID, timestamp,
+			slack.MsgOptionText(
+				":x: Something went wrong while running the Github Action!", false),
+		)
+	}()
+
+	cmd := GenerateGithubCommandWithArgs(
+		fmt.Sprintf(
+			"32728677 -R lacework-dev/lacework-cli-signing --field mfa_token=%s --field branch_or_tag=%s",
+			mfaToken, tag,
+		),
+	)
+	logger.Infow("running github workflow", "command", cmd.String())
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return errors.Wrap(err, "unable to create StdoutPipe")
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return errors.Wrap(err, "unable to create StderrPipe")
+	}
+
+	merged := io.MultiReader(stderr, stdout)
+	go readCommandBuffer(bufio.NewScanner(merged))
+
+	if err := cmd.Start(); err != nil {
+		return errors.Wrap(err, "unable to start command, buffer error")
+	}
+
+	err = cmd.Wait()
+	if err == nil {
+		success = true
+	}
+	return err
+}
+
+func renderPayloadToSignCLI(tag, pipeline string) []slack.Block {
+	headerText := slack.NewTextBlockObject(
+		slack.MarkdownType,
+		"*A new release of the Lacework CLI is ready to be signed.*\n\n"+
+			"Only authorized users with Okta Verify configured can approve this action.",
+		false, false)
+	headerSection := slack.NewSectionBlock(headerText, nil, nil)
+
+	detailsText := slack.NewTextBlockObject(slack.MarkdownType,
+		"*:1234: Version:* "+tag+
+			"\n*:win-as-a-team: Approver:* <!subteam^S01JP5A3ACQ|@allies>\n"+
+			"\n*:codefresh: Triggered by pipeline:*\n"+pipeline+"\n"+
+			"\n*:gear: Approve to run Github Action:*\n"+
+			"https://github.com/lacework-dev/lacework-cli-signing/actions\n", false, false)
+	detailsImage := slack.NewImageBlockElement(
+		"https://upload.wikimedia.org/wikipedia/commons/c/c7/Windows_logo_-_2012.png",
+		"windows logo",
+	)
+
+	detailsSection := slack.NewSectionBlock(detailsText, nil, slack.NewAccessory(detailsImage))
+
+	inputTxt := slack.PlainTextInputBlockElement{
+		Type:      "plain_text_input",
+		ActionID:  SlackMfaTokenForGithubAction,
+		Multiline: false,
+		MaxLength: 6, // Tokens are always 6 numbers
+	}
+
+	inputBlock := slack.NewInputBlock(
+		SlackSignLaceworkCLIGithubAction,
+		slack.NewTextBlockObject(
+			slack.PlainTextType,
+			":key: MFA Token",
+			false,
+			false,
+		),
+		nil,
+		inputTxt,
+	)
+
+	// Approve Button
+	approveBtnTxt := slack.NewTextBlockObject(slack.PlainTextType, "Approve", false, false)
+	approveBtn := slack.NewButtonBlockElement("", "click_me", approveBtnTxt)
+	actionBlock := slack.NewActionBlock("", approveBtn)
+
+	return []slack.Block{
+		headerSection,
+		detailsSection,
+		inputBlock,
+		actionBlock,
+	}
 }

--- a/main.go
+++ b/main.go
@@ -7,12 +7,30 @@ func main() {
 		logger.Fatalw("unable to load config", "error", err.Error())
 	}
 
+	// validate environment
+	validateEnvironment(config)
+
+	// connec to to Slack
+	client, api, err := connectToSlackViaSocketmode()
+	if err != nil {
+		logger.Fatalw("unable to connect to slack", "error", err.Error())
+	}
+
+	// goroutine to listen to Slack events
+	go listenToSlackEvents(client, api, config)
+
+	if err := client.Run(); err != nil {
+		logger.Fatalw("unable to run ally Slack app", "error", err.Error())
+	}
+}
+
+func validateEnvironment(config *c) {
 	// verify if the codefresh CLI is installed
 	if !codefreshCLIExists() {
 		logger.Fatalw("missing dependency", "bin", "codefresh")
 	}
 
-	// verify if the github CLI is installed
+	// verify if the Github CLI is installed
 	if !githubCLIExists() {
 		logger.Fatalw("missing dependency", "bin", "gh")
 	}
@@ -25,21 +43,8 @@ func main() {
 		)
 	}
 
-	// verify that the github CLI is configured via environment variable
+	// verify that the Github CLI is configured via environment variable
 	if err := config.verifyGithubCLIConfig(); err != nil {
 		logger.Fatalw("Github CLI not configured", "error", err.Error())
-	}
-
-	// connecto to Slack
-	client, api, err := connectToSlackViaSocketmode()
-	if err != nil {
-		logger.Fatalw("unable to connect to slack", "error", err.Error())
-	}
-
-	// goroutine to listen to Slack events
-	go listenToSlackEvents(client, api, config)
-
-	if err := client.Run(); err != nil {
-		logger.Fatalw("unable to run ally Slack app", "error", err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,12 +12,22 @@ func main() {
 		logger.Fatalw("missing dependency", "bin", "codefresh")
 	}
 
+	// verify if the github CLI is installed
+	if !githubCLIExists() {
+		logger.Fatalw("missing dependency", "bin", "gh")
+	}
+
 	// verify that there is a codefresh config on disk
 	// if there is not one, try to configure it
 	if err := config.verifyCodefreshConfig(); err != nil {
-		logger.Fatalw("unable to configure the codefresh CLI",
+		logger.Fatalw("unable to configure the Codefresh CLI",
 			"error", err.Error(),
 		)
+	}
+
+	// verify that the github CLI is configured via environment variable
+	if err := config.verifyGithubCLIConfig(); err != nil {
+		logger.Fatalw("Github CLI not configured", "error", err.Error())
 	}
 
 	// connecto to Slack

--- a/slack.go
+++ b/slack.go
@@ -264,7 +264,7 @@ func handleAppMentionEvent(api *slack.Client, config *c, event *slackevents.AppM
 		slack.MarkdownType,
 		":waving: Hi there!\n\n"+
 			"There are three things I can help you with:\n\n"+
-			"*1. To trigger releases from the following <list of projects|https://lacework.atlassian.net/l/cp/J73uu2wh>*\nType: `/release`\n\n"+
+			"*1. To trigger releases from the following <https://lacework.atlassian.net/l/cp/J73uu2wh|list of projects>*\nType: `/release`\n\n"+
 			"*2. To sign the Lacework CLI artifacts*\nType: `@release_ally sign_cli VERSION BUILD_LINK`\n\n"+
 			"*3. To trigger Github Workflows*\nType: `@release_ally trigger_action:WORKFLOW_ID --repo [HOST/]OWNER/REPO`\n\n"+
 			"",


### PR DESCRIPTION
The Release Ally Slack App can now handle AppMention events!

We support two events:

1. The signature of the Lacework CLI via Github Action Workflow with the
   message:
   ```
   @release_ally sign_cli v0.55.0 https://g.codefresh.io/build/abc123
   ```
2. Triggering ANY Github Action Workflow with the message:
   ```
   @release_ally trigger_action:WORKFLOW_ID --repo [HOST/]OWNER/REPO"
   ```

You can also ask for `help` to the `@release_ally` Slack App.

```
@release_ally help
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>
