### PR TITLE
fix: format AppMention Slack notification

### DIFF
--- a/gh_cli.go
+++ b/gh_cli.go
@@ -129,7 +129,7 @@ func runGithubActionWithCallback(api *slack.Client, config *c,
 	defer func() {
 		if success {
 			updateSlackMessage(api, callback.Channel.ID, timestamp,
-				slack.MsgOptionText("That was a success! :chewbacca:", false),
+				slack.MsgOptionText("That was a success! :megamix:", false),
 			)
 			return
 		}

--- a/slack.go
+++ b/slack.go
@@ -165,13 +165,7 @@ func handleEventMessage(api *slack.Client, config *c, event slackevents.EventsAP
 //         MESSAGE: "<@U0279A42HV0> hello"
 // ```
 func handleAppMentionEvent(api *slack.Client, config *c, event *slackevents.AppMentionEvent) error {
-
-	notifySlackChannel(api,
-		config.NotifySlackChannel,
-		fmt.Sprintf(
-			"User <@%s> is interacting with the release ally app! :woohoo:\n\n*Message:*\n> %s",
-			event.User, event.Text),
-	)
+	notifySlackChannel(api, config.NotifySlackChannel, formatAppMentionMsg(event.User, event.Channel, event.Text))
 
 	if strings.Contains(event.Text, "sign_cli") {
 		actionArgs := strings.Split(event.Text, " ")
@@ -360,4 +354,23 @@ func handleInteractiveEvent(api *slack.Client, config *c, callback slack.Interac
 	}
 
 	return nil
+}
+
+func formatAppMentionMsg(user, channel, text string) (msg string) {
+	// Who
+	if len(user) == 0 {
+		msg = "Incoming webhook interacting with the release ally app! :woohoo:"
+	} else {
+		msg = fmt.Sprintf("User <@%s> is interacting with the release ally app! :woohoo:", user)
+	}
+
+	// What
+	msg = fmt.Sprintf("%s\n\n*Message:*\n> %s", msg, text)
+
+	// Where
+	if len(channel) != 0 {
+		msg = fmt.Sprintf("%s\n\n*Channel:* <#%s>", msg, channel)
+	}
+
+	return
 }


### PR DESCRIPTION
This PR is fixing this notification message:
![Screen Shot 2022-08-29 at 8 23 26 AM](https://user-images.githubusercontent.com/5712253/187236438-1becf737-d481-48dd-a987-09dd1351003f.png)

Instead we are going to display:
> Incoming webhook interacting with the release ally app! 

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>